### PR TITLE
Adding additional information: soft_closed and more

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -42,21 +42,35 @@ This is currently very incomplete as there is a lot of data in there.
 
 -   The user version contains a subset of the data of the LUST version
 
--   Project start- and end-related dates: Currently only in the LUST version, but we want
-    this to change.
+-   Project start- and end-related dates: In both the LUST and the user version of the files.
 
     -   `open_date`: Date/time of opening of the project, e.g., `20251031225126Z`
 
     -   `end_date`: Date/time at which compute ends, e.g., `20261031050000Z`
 
+        Puhuri projects with an end time of 04:00 UTC are definitely closed early on on
+        that day.
+
     -   `closed_date`: Date/time at which data access closes, e.g., `20270129050000Z`
+
+-   Compute-related fields:
+
+    -   `enabled_partitions`: A list of all partitions that a project can use. This is unfortunately
+        not reset to an empty list if the project does not have an allocation anymore.
+
+        Instead, there is also the structure `partition_access` with per partition a field `allowed`
+        that is reset to false if the project has no longer access to a partition.So to print the partitions,
+        it would be better to go through that list and to see which partitions are allowed.
 
 -   Some LUST-only fields:
 
     -   `allocator_country`: lumi-be, lumi-ch, lumi-cz, lumi-dk, lumi-ee, 
         lumi-fi, lumi-is, lumi-ju, lumi-lust, lumi-lustt, lumi-nl, lumi-no, lumi-pl, 
-        lumi-se, lumi-training
+        lumi-se, lumi-training, efp-lumi-c, efp-lumi-g
         
         lumi-lust and lumi-lustt have been used inconsistently in the past. lumi-training 
         is for new trainings.
+
+    -   `is_softclosed`: Boolean, telling if a project is soft closed or not, which may point
+        to issues with the account of the PI.
 

--- a/src/lumi-ldap-projectinfo.lua
+++ b/src/lumi-ldap-projectinfo.lua
@@ -830,6 +830,14 @@ do
 
     if mode == 'lust' then
 
+        if project_info['is_softclosed'] ~= nil then
+            if project_info['is_softclosed'] then
+                print( lustview_on .. '  - Project is in soft_closed state, which may point to issues with the account of the PI.' .. lustview_off )
+            else
+                print( lustview_on .. '  - Project is not in soft_closed state (is_softclosed is false)' .. lustview_off )
+            end
+        end
+
         if project_info['valid_compute_project']  ~=  nil then
             if project_info['valid_compute_project'] then
                 print( lustview_on .. '  - Project is valid for compute (field valid_compute_project true)' .. lustview_off )
@@ -1007,7 +1015,33 @@ do
        project_info['billing']['qpu_secs']['alloc'] == 0 then
 
         print( '- The project has no allocation' )
-       
+
+        if project_info['billing']['cpu_hours']['remaining'] < 0 or
+           project_info['billing']['gpu_hours']['remaining'] < 0 or
+           project_info['billing']['storage_hours']['remaining'] < 0 or
+           project_info['billing']['qpu_secs']['remaining'] < 0 then
+
+            -- We have information about use of billing units so far, so lets print that information.
+
+            print( '  Used resources:' )
+
+            if project_info['billing']['cpu_hours']['remaining'] < 0 then
+                print('  - CPU Khours:      ' .. string.format( '%.3f', -project_info['billing']['cpu_hours']['remaining'] / 1000 ) )
+            end
+            
+            if project_info['billing']['gpu_hours']['remaining'] < 0 then
+                print('  - GPU hours:       ' .. string.format( '%d', -project_info['billing']['gpu_hours']['remaining'] ) )
+            end
+            
+            if project_info['billing']['storage_hours']['remaining'] < 0 then
+                print('  - Storage TBhours: ' .. string.format( '%d', -project_info['billing']['storage_hours']['remaining'] ) )
+            end
+            
+            if project_info['billing']['qpu_secs']['remaining'] < 0 then
+                print('  - QPU seconds:     ' .. string.format( '%d', -project_info['billing']['qpu_secs']['remaining'] ) )
+            end
+            
+        end
        
     else
         
@@ -1105,6 +1139,9 @@ if mode == 'lust' then
     print(                '- Same information for LUST and user' )
     print( lustview_on .. '- View for LUST only' .. lustview_off )
     print( userview_on .. '- View for user only' .. userview_off )
-    print( debug_on    .. '- Debug information\n'  .. debug_off )
-
+    if debug then
+        print( debug_on    .. '- Debug information'  .. debug_off )
+    end
+    print()
+    
 end


### PR DESCRIPTION
Information added to the output:

-   Project is soft_closed or not (lumi-ldap-projectinfo in LUST mode)
-   Consumed billing units for projects with no allocation (lumi-ldap-projectinfo, LUST and user mode)